### PR TITLE
feat: 推論モデルを GPT-5.6 Terra (Responses API) へ切り替える

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -120,6 +120,28 @@ You can change the settings by modifying the values under the `context` section 
 ## Common Settings
 * `modelRegion`: The region to use Amazon Bedrock. Enter the region code of the region you want to use from among the regions where Amazon Bedrock is available.
 * `modelId`: The model ID of the base model to be used with Amazon Bedrock. Refer to the documentation for the model ID of each model.
+* `modelApiMode`: How the model is invoked. Set `converse` for models served by the Converse API on the `bedrock-runtime` endpoint, or `responses` for models served only by the Responses API on the `bedrock-mantle` endpoint. Defaults to `converse` when omitted. `modelId` and `modelApiMode` must agree, otherwise the Lambda function raises an error on startup.
+
+### Switching the model
+
+`modelId` and `modelApiMode` are always changed together, because a model is reachable through only one of the two APIs.
+
+| Model | `modelId` | `modelApiMode` |
+| --- | --- | --- |
+| Amazon Nova Pro | `us.amazon.nova-pro-v1:0` | `converse` |
+| OpenAI GPT-5.6 Terra | `openai.gpt-5.6-terra` | `responses` |
+
+1. Edit both values in the `context` section of [cdk.json](cdk.json).
+2. Deploy with `cdk deploy`. The CDK app rejects an unknown `modelApiMode` at synth time, and the Lambda function rejects a mismatched pair at startup, so a half-finished edit fails fast rather than reaching production.
+3. Check CloudWatch Logs for the first few invocations of `NotifyNewEntry`.
+
+Notes when moving to a `responses` model:
+
+* The stack grants `bedrock-mantle:CallWithBearerToken` and `bedrock-mantle:CreateInference` only in `responses` mode. Both are required; granting only the former returns `AccessDeniedException`.
+* The Lambda timeout is raised from 180 to 600 seconds in `responses` mode, because reasoning models spend considerably longer per article.
+* Reasoning models such as GPT-5.6 Terra reject `temperature` and `top_p`. Sending either returns HTTP 400 `unsupported_parameter`, so only `max_output_tokens` and the reasoning effort are passed on that path.
+
+To roll back, restore the previous `modelId` and `modelApiMode` pair and run `cdk deploy` again. No code change is needed, because both call paths remain in the function.
 
 ## summarizers
 Configure the prompt for summarizing the input to the generative AI.

--- a/DEPLOY_ja.md
+++ b/DEPLOY_ja.md
@@ -136,6 +136,28 @@ cdk destroy --profile your-profile-name
 ## 共通設定
 * `modelRegion`: Amazon Bedrock を利用するリージョン。Amazon Bedrock を利用可能なリージョンの中から、利用したいリージョンのリージョンコードを入力してください。
 * `modelId`: Amazon Bedrock で利用する基盤モデルの model ID。各モデルの model ID はドキュメントを参照ください。
+* `modelApiMode`: モデルの呼び出し方式。`bedrock-runtime` エンドポイントの Converse API で提供されるモデルは `converse`、`bedrock-mantle` エンドポイントの Responses API でのみ提供されるモデルは `responses` を指定します。省略時は `converse` として扱われます。`modelId` と `modelApiMode` が対応していない場合、Lambda 関数は起動時にエラーになります。
+
+### モデルの切り替え手順
+
+モデルはどちらか一方の API でしか提供されないため、`modelId` と `modelApiMode` は必ず同時に変更します。
+
+| モデル | `modelId` | `modelApiMode` |
+| --- | --- | --- |
+| Amazon Nova Pro | `us.amazon.nova-pro-v1:0` | `converse` |
+| OpenAI GPT-5.6 Terra | `openai.gpt-5.6-terra` | `responses` |
+
+1. [cdk.json](cdk.json) の `context` 内で両方の値を変更します。
+2. `cdk deploy` でデプロイします。不正な `modelApiMode` は synth 時点で、`modelId` との不一致は Lambda 起動時に検出されるため、片方だけ変更した状態が本番に到達することはありません。
+3. `NotifyNewEntry` の CloudWatch Logs で最初の数件を確認します。
+
+`responses` のモデルへ切り替える場合の注意点は次のとおりです。
+
+* スタックは `responses` のときにのみ `bedrock-mantle:CallWithBearerToken` と `bedrock-mantle:CreateInference` を付与します。両方が必要で、前者だけでは `AccessDeniedException` になります。
+* 推論モデルは記事あたりの所要時間が長いため、`responses` のときは Lambda のタイムアウトを 180 秒から 600 秒に引き上げます。
+* GPT-5.6 Terra のような推論モデルは `temperature` と `top_p` を受け付けません。指定すると HTTP 400 `unsupported_parameter` になるため、この経路では `max_output_tokens` と推論の effort のみを渡します。
+
+元に戻す場合は、以前の `modelId` と `modelApiMode` の組み合わせに戻して `cdk deploy` を実行します。両方の呼び出し経路が関数内に残っているため、コードの変更は不要です。
 
 ## summarizers
 生成 AI に入力する要約用プロンプトの設定を行います。

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The project pins direct dependencies in `requirements.txt` (e.g. `package>=x.y.z
 
 For deployment instructions including Webhook URL setup, AWS Systems Manager Parameter Store configuration, language settings, and CDK commands, see [DEPLOY.md](DEPLOY.md).
 
+To change the model used for summarization, see [Switching the model](DEPLOY.md#switching-the-model). Both the Converse and Responses call paths stay in the function, so switching is a configuration change rather than a code change.
+
 ## Third Party Services
 
 This code interacts with Slack which has terms published at [Terms Page (Slack)](https://slack.com/main-services-agreement), and pricing described at [Pricing Page (Slack)](https://slack.com/pricing). You should be familiar with the pricing and confirm that your use case complies with the terms before proceeding.

--- a/cdk.json
+++ b/cdk.json
@@ -19,7 +19,8 @@
     },
     "context": {
         "modelRegion": "us-west-2",
-        "modelId": "us.amazon.nova-pro-v1:0",
+        "modelId": "openai.gpt-5.6-terra",
+        "modelApiMode": "responses",
         "summarizers": {
             "AwsSolutionsArchitectEnglish": {
                 "outputLanguage": "English.",

--- a/lambda/notify-to-app/index.py
+++ b/lambda/notify-to-app/index.py
@@ -11,17 +11,76 @@ import urllib.request
 
 import boto3
 import cloudscraper
+import openai
 from botocore.exceptions import ClientError
 from bs4 import BeautifulSoup
 from strands import Agent
 from strands.models import BedrockModel
+from strands.models.openai_responses import OpenAIResponsesModel
 
 MODEL_ID = os.environ["MODEL_ID"]
 MODEL_REGION = os.environ["MODEL_REGION"]
+# "converse" routes through bedrock-runtime; "responses" routes through the
+# bedrock-mantle endpoint. Defaults to converse so existing deployments that
+# predate this variable keep working unchanged.
+MODEL_API_MODE = os.environ.get("MODEL_API_MODE", "converse")
 NOTIFIERS = json.loads(os.environ["NOTIFIERS"])
 SUMMARIZERS = json.loads(os.environ["SUMMARIZERS"])
 
 ssm = boto3.client("ssm")
+
+# Models that are only served through the Responses API on bedrock-mantle.
+# Add new Responses-only model IDs here.
+RESPONSES_ONLY_MODEL_IDS = frozenset({"openai.gpt-5.6-terra"})
+
+
+def validate_model_config(model_id, model_api_mode):
+    """Fail fast when the model ID and the API mode do not match."""
+
+    if model_api_mode not in ("converse", "responses"):
+        raise ValueError(f"Unsupported MODEL_API_MODE: {model_api_mode!r}")
+
+    is_responses_only = model_id in RESPONSES_ONLY_MODEL_IDS
+    if is_responses_only and model_api_mode != "responses":
+        raise ValueError(
+            f"Model {model_id!r} is only available through the Responses API; "
+            f"set MODEL_API_MODE=responses (got {model_api_mode!r})"
+        )
+    if not is_responses_only and model_api_mode == "responses":
+        raise ValueError(
+            f"Model {model_id!r} is not registered as a Responses-only model; "
+            f"set MODEL_API_MODE=converse (got {model_api_mode!r})"
+        )
+
+
+validate_model_config(MODEL_ID, MODEL_API_MODE)
+
+
+def build_model(max_tokens):
+    """Build the Strands model for the configured API mode."""
+
+    if MODEL_API_MODE == "responses":
+        # GPT-5.6 Terra rejects top_p, so only temperature is passed here.
+        return OpenAIResponsesModel(
+            model_id=MODEL_ID,
+            bedrock_mantle_config={"region": MODEL_REGION},
+            params={
+                "temperature": 0.1,
+                "max_output_tokens": max_tokens,
+                "reasoning": {"effort": "medium"},
+            },
+        )
+
+    return BedrockModel(
+        params={
+            "temperature": 0.1,
+            "top_p": 0.1,
+            "max_tokens": max_tokens
+        },
+        model_id=MODEL_ID,
+        region_name=MODEL_REGION,
+        streaming=False,
+    )
 
 
 def get_blog_content(url):
@@ -244,16 +303,7 @@ FINAL CHECK before you output: When output language is Japanese, scan your <summ
 
     max_tokens = 4096
 
-    model = BedrockModel(
-        params={
-            "temperature": 0.1,
-            "top_p": 0.1,
-            "max_tokens": max_tokens
-        },
-        model_id=MODEL_ID,
-        region_name=MODEL_REGION,
-        streaming=False,
-    )
+    model = build_model(max_tokens)
 
     agent = Agent(
         model=model,
@@ -291,6 +341,11 @@ FINAL CHECK before you output: When output language is Japanese, scan your <summ
             raise
         else:
             raise error
+    except openai.APIError as error:
+        # The Responses path surfaces failures as openai SDK exceptions rather
+        # than botocore ClientError.
+        print(f"Responses API (bedrock-mantle) error: {error}")
+        raise
 
     return summary, twitter
 

--- a/lambda/notify-to-app/index.py
+++ b/lambda/notify-to-app/index.py
@@ -60,12 +60,14 @@ def build_model(max_tokens):
     """Build the Strands model for the configured API mode."""
 
     if MODEL_API_MODE == "responses":
-        # GPT-5.6 Terra rejects top_p, so only temperature is passed here.
+        # GPT-5.6 Terra rejects both top_p and temperature: as a reasoning
+        # model it only accepts their defaults, and sending either returns
+        # HTTP 400 unsupported_parameter. Determinism is instead influenced
+        # through the reasoning effort level.
         return OpenAIResponsesModel(
             model_id=MODEL_ID,
             bedrock_mantle_config={"region": MODEL_REGION},
             params={
-                "temperature": 0.1,
                 "max_output_tokens": max_tokens,
                 "reasoning": {"effort": "medium"},
             },

--- a/lambda/notify-to-app/requirements.txt
+++ b/lambda/notify-to-app/requirements.txt
@@ -3,4 +3,4 @@
 beautifulsoup4>=4.14.3
 boto3>=1.42.46,<2
 cloudscraper>=1.2.71
-strands-agents>=1.25.0
+strands-agents[openai]>=1.39.0

--- a/lambda/notify-to-app/test_index.py
+++ b/lambda/notify-to-app/test_index.py
@@ -11,6 +11,7 @@ import pytest
 os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
 os.environ.setdefault("MODEL_ID", "test-model-id")
 os.environ.setdefault("MODEL_REGION", "us-west-2")
+os.environ.setdefault("MODEL_API_MODE", "converse")
 os.environ.setdefault("NOTIFIERS", json.dumps({
     "TestNotifier": {
         "summarizerName": "AwsSolutionsArchitectJapanese",
@@ -152,7 +153,7 @@ class TestPushNotificationFallback:
         }
         with patch("index.ssm.get_parameter", return_value={"Parameter": {"Value": "https://hooks.example.com"}}), \
              patch("index.get_blog_content", return_value=None), \
-             patch("index.summarize_blog", return_value=("summary", "detail", "twitter")) as mock_summarize, \
+             patch("index.summarize_blog", return_value=("summary", "twitter")) as mock_summarize, \
              patch("index.urllib.request.urlopen"), \
              patch("index.time.sleep"):
             index.push_notification([item])

--- a/lib/whats-new-summary-notifier-stack.ts
+++ b/lib/whats-new-summary-notifier-stack.ts
@@ -30,6 +30,14 @@ export class WhatsNewSummaryNotifierStack extends Stack {
     // prefix. Strip it to obtain the underlying foundation model ID for IAM policy ARNs.
     const baseModelId = modelId.replace(/^(us|eu|ap)\./, '');
 
+    // "converse" calls bedrock-runtime; "responses" calls the bedrock-mantle
+    // endpoint, which some models (e.g. GPT-5.6 Terra) require exclusively.
+    const modelApiMode = this.node.tryGetContext('modelApiMode') ?? 'converse';
+    if (modelApiMode !== 'converse' && modelApiMode !== 'responses') {
+      throw new Error(`modelApiMode must be "converse" or "responses", got: ${modelApiMode}`);
+    }
+    const usesResponsesApi = modelApiMode === 'responses';
+
     const notifiers: [] = this.node.tryGetContext('notifiers');
     const summarizers: [] = this.node.tryGetContext('summarizers');
 
@@ -55,6 +63,26 @@ export class WhatsNewSummaryNotifierStack extends Stack {
               `arn:aws:bedrock:${modelRegion}:${accountId}:inference-profile/*`,
             ],
           }),
+          // The bedrock-mantle path mints a short-lived bearer token from the
+          // execution role's credentials, then creates an inference against the
+          // project. Both actions are required; CallWithBearerToken alone fails.
+          // Resource scoping follows the AWS managed policy
+          // AmazonBedrockMantleInferenceAccess: CallWithBearerToken is not
+          // resource-scopable and must use "*", CreateInference targets projects.
+          ...(usesResponsesApi
+            ? [
+                new PolicyStatement({
+                  actions: ['bedrock-mantle:CallWithBearerToken'],
+                  effect: Effect.ALLOW,
+                  resources: ['*'],
+                }),
+                new PolicyStatement({
+                  actions: ['bedrock-mantle:CreateInference'],
+                  effect: Effect.ALLOW,
+                  resources: [`arn:aws:bedrock-mantle:${modelRegion}:${accountId}:project/*`],
+                }),
+              ]
+            : []),
         ],
       })
     );
@@ -96,13 +124,16 @@ export class WhatsNewSummaryNotifierStack extends Stack {
       bundling: pythonLambdaBundling,
       handler: 'handler',
       index: 'index.py',
-      timeout: Duration.seconds(180),
+      // Reasoning models on the Responses path spend far longer per article;
+      // 180s was observed to time out, 600s leaves headroom.
+      timeout: Duration.seconds(usesResponsesApi ? 600 : 180),
       logGroup: notifyNewEntryLogGroup,
       role: notifyNewEntryRole,
       reservedConcurrentExecutions: 1,
       environment: {
         MODEL_ID: modelId,
         MODEL_REGION: modelRegion,
+        MODEL_API_MODE: modelApiMode,
         NOTIFIERS: JSON.stringify(notifiers),
         SUMMARIZERS: JSON.stringify(summarizers),
       },


### PR DESCRIPTION
Closes #18

> **注記**: 本番環境には既に本ブランチ相当の内容をデプロイ済みで稼働中です。本 PR は main を本番の状態に追いつかせるための取り込みになります。

## 概要

notify-to-app Lambda の推論モデルを Amazon Nova Pro から OpenAI GPT-5.6 Terra へ切り替える。

GPT-5.6 Terra は `bedrock-mantle` エンドポイント経由の Responses API でのみ提供されるため、`modelId` の差し替えだけでは動作しない。`modelApiMode` で Converse 経路 (`bedrock-runtime`) と Responses 経路 (`bedrock-mantle`) を切り替える構造を導入し、両経路をコードに残すことで設定だけで元のモデルへ戻せるようにした。

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `cdk.json` | `modelId` を `openai.gpt-5.6-terra` に変更、`modelApiMode: "responses"` を追加 |
| `lib/whats-new-summary-notifier-stack.ts` | `modelApiMode` の読み込みと検証、Responses 時のみ `bedrock-mantle` 権限を付与、タイムアウトを条件分岐 (600s / 180s) |
| `lambda/notify-to-app/index.py` | `validate_model_config()` と `build_model()` を追加、`openai.APIError` を捕捉 |
| `lambda/notify-to-app/requirements.txt` | `bedrock_mantle_config` のため `strands-agents[openai]>=1.39.0` |
| `lambda/notify-to-app/test_index.py` | `MODEL_API_MODE` の既定値を追加、`summarize_blog` モックの 3 値 → 2 値修正 (付随修正、後述) |

`MODEL_API_MODE` は未設定時 `converse` にフォールバックするため、この変数を持たない既存デプロイもそのまま動作する。

## 実機検証で判明した制約

いずれも本番での実呼び出しにより判明し、対応済み。

- **IAM**: `bedrock-mantle:CallWithBearerToken` だけでは `AccessDeniedException` になる。`bedrock-mantle:CreateInference` も必要。スコープはマネージドポリシー `AmazonBedrockMantleInferenceAccess` に合わせ、前者を `*`、後者を `project/*` とした
- **パラメータ**: GPT-5.6 Terra は `top_p` と `temperature` を受け付けず、明示指定すると HTTP 400 `unsupported_parameter` になる。推論モデルとして既定値以外を許容しないため、Responses 経路では `max_output_tokens` と `reasoning.effort` のみを渡す
- **タイムアウト**: `reasoning_effort=medium` では 180 秒で `Status: timeout` が発生する。Responses 時のみ 600 秒に引き上げた

## 付随する修正

`test_index.py` の `push_notification` フォールバックテストが `summarize_blog` を 3 値タプルでモックしていたが、本番コードは 2 値でアンパックしており、クリーンなチェックアウトでも失敗していた。本 PR の変更とは無関係な既存不具合だが、テストスイートを緑にするため同時に修正した。

## 検証

- `npm run build` 成功
- `pytest lambda/notify-to-app/test_index.py` 14 件成功
- `pytest lambda/rss-crawler/test_index.py` 9 件成功
- `ruff check` の指摘は main と同一の 4 件のみ (新規指摘なし)
- `cdk synth` で IAM・環境変数・タイムアウトが意図どおり生成されることを確認
- 本番デプロイ後、実記事で invoke し 36.3 秒で Slack 投稿を確認 (CodeSize 44.2MB)

### 未実施の検証

`modelApiMode` を `converse` に戻した状態での切り戻し smoke test は本ブランチでは未実施 (Issue #18 の完了条件のうち 1 項目)。同等の確認は前回実装で行っているが、本ブランチでは `MODEL_API_MODE` 未設定時のフォールバックなど経路が変わっているため、改めて確認するか Issue 側の残課題として扱うかを判断したい。

## 残課題

- Converse 経路の `BedrockModel(params={...})` は strands-agents の現行版では無効キーとして無視される (main 由来の既存不具合)。Terra 本番経路には影響しないため別 PR とする
- `timeout: 600` と `reservedConcurrentExecutions: 1` の組み合わせで DynamoDB Stream が滞留しないか、初週は duration を観測する

🤖 Generated with [Claude Code](https://claude.com/claude-code)